### PR TITLE
fixes excessive error logs from task service

### DIFF
--- a/src/Player.Vm.Api/Domain/Vsphere/Extensions/VimExtensions.cs
+++ b/src/Player.Vm.Api/Domain/Vsphere/Extensions/VimExtensions.cs
@@ -139,8 +139,13 @@ namespace Player.Vm.Api.Domain.Vsphere.Extensions
 
         public static object GetProperty(this ObjectContent content, string name)
         {
-            return content
-                .propSet.Where(p => p.name == name)
+            if (content.propSet == null)
+            {
+                return null;
+            }
+
+            return content.propSet
+                .Where(p => p.name == name)
                 .Select(p => p.val)
                 .SingleOrDefault();
         }

--- a/src/Player.Vm.Api/Domain/Vsphere/Services/TaskService.cs
+++ b/src/Player.Vm.Api/Domain/Vsphere/Services/TaskService.cs
@@ -114,7 +114,7 @@ namespace Player.Vm.Api.Domain.Vsphere.Services
                 }
                 catch (Exception ex)
                 {
-                    this._logger.LogError(ex.Message);
+                    this._logger.LogError(ex, "Exception in processTasks");
                 }
             }
         }
@@ -139,8 +139,14 @@ namespace Player.Vm.Api.Domain.Vsphere.Services
                 {
                     try
                     {
-                        var vmRef = ((ManagedObjectReference)task.GetProperty("info.entity")).Value;
-                        var vmId = _connectionService.GetVmIdByRef(vmRef);
+                        Guid? vmId = null;
+                        var vmRef = task.GetProperty("info.entity") != null ? ((ManagedObjectReference)task.GetProperty("info.entity")).Value : null;
+
+                        if (vmRef != null)
+                        {
+                            vmId = _connectionService.GetVmIdByRef(vmRef);
+                        }
+
                         var broadcastTime = DateTime.UtcNow.ToString();
                         var taskId = task.GetProperty("info.key") != null ? task.GetProperty("info.key").ToString() : "";
                         var taskType = task.GetProperty("info.descriptionId") != null ? task.GetProperty("info.descriptionId").ToString() : "";
@@ -186,7 +192,7 @@ namespace Player.Vm.Api.Domain.Vsphere.Services
                     }
                     catch (Exception ex)
                     {
-                        this._logger.LogError(ex.Message);
+                        this._logger.LogError(ex, "Exception processing task");
                     }
                 }
 


### PR DESCRIPTION
- check for null propSet when processing tasks
   - propSet will be null and missingProperties show up when a task is processed but the account does not have permission to access that task
- print full exceptions instead of just exception.message to help troubleshoot future errors