### PR TITLE
add health checks

### DIFF
--- a/src/Player.Vm.Api/Domain/Services/HealthChecks/ConnectionServiceHealthCheck.cs
+++ b/src/Player.Vm.Api/Domain/Services/HealthChecks/ConnectionServiceHealthCheck.cs
@@ -1,0 +1,48 @@
+/*
+Copyright 2021 Carnegie Mellon University. All Rights Reserved. 
+ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+*/
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+
+namespace Player.Vm.Api.Domain.Services.HealthChecks
+{
+    public class ConnectionServiceHealthCheck : IHealthCheck
+    {
+        private int _healthAllowance = 90;
+        private DateTime _lastRun = DateTime.Now;
+
+        public int HealthAllowance
+        {
+            get => _healthAllowance;
+            set => _healthAllowance = value;
+        }
+        public DateTime LastRun
+        {
+            get => _lastRun;
+            set => _lastRun = value;
+        }
+        public void CompletedRun()
+        {
+            LastRun = DateTime.Now;
+        }
+
+        public Task<HealthCheckResult> CheckHealthAsync(
+            HealthCheckContext context,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if ((DateTime.Now - LastRun).TotalSeconds < HealthAllowance)
+            {
+                return Task.FromResult(
+                    HealthCheckResult.Healthy("The Connection Service is responsive."));
+            }
+
+            return Task.FromResult(
+                HealthCheckResult.Unhealthy("The Connection Service is not responsive."));
+        }
+    }
+} 

--- a/src/Player.Vm.Api/Domain/Services/HealthChecks/TaskServiceHealthCheck.cs
+++ b/src/Player.Vm.Api/Domain/Services/HealthChecks/TaskServiceHealthCheck.cs
@@ -1,0 +1,48 @@
+/*
+Copyright 2021 Carnegie Mellon University. All Rights Reserved. 
+ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+*/
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+
+namespace Player.Vm.Api.Domain.Services.HealthChecks
+{
+    public class TaskServiceHealthCheck : IHealthCheck
+    {
+        private int _healthAllowance = 90;
+        private DateTime _lastRun = DateTime.Now;
+
+        public int HealthAllowance
+        {
+            get => _healthAllowance;
+            set => _healthAllowance = value;
+        }
+        public DateTime LastRun
+        {
+            get => _lastRun;
+            set => _lastRun = value;
+        }
+        public void CompletedRun()
+        {
+            LastRun = DateTime.Now;
+        }
+
+        public Task<HealthCheckResult> CheckHealthAsync(
+            HealthCheckContext context,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if ((DateTime.Now - LastRun).TotalSeconds < HealthAllowance)
+            {
+                return Task.FromResult(
+                    HealthCheckResult.Healthy("The Task Service is responsive."));
+            }
+
+            return Task.FromResult(
+                HealthCheckResult.Unhealthy("The Task Service is not responsive."));
+        }
+    }
+} 

--- a/src/Player.Vm.Api/Domain/Vsphere/Options/VsphereOptions.cs
+++ b/src/Player.Vm.Api/Domain/Vsphere/Options/VsphereOptions.cs
@@ -21,5 +21,6 @@ namespace Player.Vm.Api.Domain.Vsphere.Options
         public int Timeout { get; set; }
         public int CheckTaskProgressIntervalMilliseconds { get; set; }
         public int ReCheckTaskProgressIntervalMilliseconds { get; set; }
+        public int HealthAllowanceSeconds { get; set; }
     }
 }

--- a/src/Player.Vm.Api/Features/HealthCheck/HealthCheckController.cs
+++ b/src/Player.Vm.Api/Features/HealthCheck/HealthCheckController.cs
@@ -1,0 +1,68 @@
+/*
+Copyright 2021 Carnegie Mellon University. All Rights Reserved. 
+ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+*/
+
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using System.Threading;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Player.Vm.Api.Features.HealthCheck
+{    
+    [Route("api/")]
+    [ApiController]
+    [AllowAnonymous]
+    public class HealthController : ControllerBase
+    {
+        private readonly HealthCheckService healthCheckService;
+
+        public HealthController(HealthCheckService healthCheckService)
+        {
+            this.healthCheckService = healthCheckService;
+        }
+
+        /// <summary>
+        /// Checks the liveliness health endpoint
+        /// </summary>
+        /// <remarks>
+        /// Returns a HealthReport of the liveliness health check
+        /// </remarks>
+        /// <returns></returns>
+        [HttpGet("health/live")]
+        [ProducesResponseType(typeof(HealthReport), (int)HttpStatusCode.OK)]
+        [SwaggerOperation(OperationId = "Health_GetLiveliness")]
+        public async Task<IActionResult> GetLiveliness(CancellationToken ct)
+        {
+            HealthReport report = await this.healthCheckService.CheckHealthAsync((check) => check.Tags.Contains("live"));
+            var result = new
+            {
+                status = report.Status.ToString()
+            };
+            return report.Status == HealthStatus.Healthy ? this.Ok(result) : this.StatusCode((int)HttpStatusCode.ServiceUnavailable, result);
+        }
+
+        /// <summary>
+        /// Checks the readiness health endpoint
+        /// </summary>
+        /// <remarks>
+        /// Returns a HealthReport of the readiness health check
+        /// </remarks>
+        /// <returns></returns>
+        [HttpGet("health/ready")]
+        [ProducesResponseType(typeof(HealthReport), (int)HttpStatusCode.OK)]
+        [SwaggerOperation(OperationId = "Health_GetReadiness")]
+        public async Task<IActionResult> GetReadiness(CancellationToken ct)
+        {
+            HealthReport report = await this.healthCheckService.CheckHealthAsync((check) => check.Tags.Contains("ready"));
+            var result = new
+            {
+                status = report.Status.ToString()
+            };
+            return report.Status == HealthStatus.Healthy ? this.Ok(result) : this.StatusCode((int)HttpStatusCode.ServiceUnavailable, result);
+        }
+    }
+} 

--- a/src/Player.Vm.Api/Player.Vm.Api.csproj
+++ b/src/Player.Vm.Api/Player.Vm.Api.csproj
@@ -27,5 +27,9 @@
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="3.1.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="3.1.0"/>
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="3.1.0"/>
+    <PackageReference Include="AspNetCore.HealthChecks.Sqlite" Version="3.1.0"/>
   </ItemGroup>
 </Project>

--- a/src/Player.Vm.Api/appsettings.json
+++ b/src/Player.Vm.Api/appsettings.json
@@ -64,7 +64,8 @@
     "LoadCacheAfterIterations": 5,
     "LogConsoleAccess": false,
     "CheckTaskProgressIntervalMilliseconds": 5000,
-    "ReCheckTaskProgressIntervalMilliseconds": 1000
+    "ReCheckTaskProgressIntervalMilliseconds": 1000,
+    "HealthAllowanceSeconds": 180
   },
   "RewriteHost": {
     "RewriteHost": false,


### PR DESCRIPTION
## Feature
- Adds `ready` endpoint for startup health
- Adds `live` endpoint for HostedServices health

### Configuration Addition
- Adds **Vsphere__HealthAllowanceSeconds** appsetting, which defaults to `180`, and is the amount of time, in seconds, that the background timers are allowed to run without checking in before the application is considered `unhealthy`