### PR TITLE
switch from implicit to auth code

### DIFF
--- a/src/Player.Vm.Api/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Player.Vm.Api/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -40,9 +40,10 @@ namespace Player.Vm.Api.Infrastructure.Extensions
                     Type = SecuritySchemeType.OAuth2,
                     Flows = new OpenApiOAuthFlows
                     {
-                        Implicit = new OpenApiOAuthFlow
+                        AuthorizationCode = new OpenApiOAuthFlow
                         {
                             AuthorizationUrl = new Uri(authOptions.AuthorizationUrl),
+                            TokenUrl = new Uri(authOptions.TokenUrl),
                             Scopes = new Dictionary<string, string>()
                             {
                                 {authOptions.AuthorizationScope, "public api access"}

--- a/src/Player.Vm.Api/Infrastructure/Options/AuthorizationOptions.cs
+++ b/src/Player.Vm.Api/Infrastructure/Options/AuthorizationOptions.cs
@@ -7,6 +7,7 @@ namespace Player.Vm.Api.Infrastructure.Options
     {
         public string Authority { get; set; }
         public string AuthorizationUrl { get; set; }
+        public string TokenUrl { get; set; }
         public string AuthorizationScope { get; set; }
         public string ClientId { get; set; }
         public string ClientName { get; set; }

--- a/src/Player.Vm.Api/Startup.cs
+++ b/src/Player.Vm.Api/Startup.cs
@@ -281,6 +281,7 @@ namespace Player.Vm.Api
                 c.OAuthClientId(_authOptions.ClientId);
                 c.OAuthClientSecret(_authOptions.ClientSecret);
                 c.OAuthAppName(_authOptions.ClientName);
+                c.OAuthUsePkce();
             });
         }
     }

--- a/src/Player.Vm.Api/appsettings.json
+++ b/src/Player.Vm.Api/appsettings.json
@@ -42,6 +42,7 @@
   "Authorization": {
     "Authority": "http://localhost:5000",
     "AuthorizationUrl": "http://localhost:5000/connect/authorize",
+    "TokenUrl": "http://localhost:5000/connect/token",
     "AuthorizationScope": "player player-vm",
     "ClientId": "player.vm.swagger",
     "ClientName": "Player VM Swagger UI",


### PR DESCRIPTION
### Security Fix

Change OAuth2 flow from `Implicit` to `Authorization Code` to follow best practices.

### Breaking Change
Need to add `TokenUrl` to the IdentityServer's `token` endpoint as an appsetting, and update the Client in Identity.

Addresses internal issue `CRU-1842`.