### PR TITLE
added player webhook support to enable maps for on demand events

### DIFF
--- a/src/Player.Vm.Api/Data/Migrations/Postgres/20220121152005_webhook_events.Designer.cs
+++ b/src/Player.Vm.Api/Data/Migrations/Postgres/20220121152005_webhook_events.Designer.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Player.Vm.Api.Data;
@@ -17,9 +18,10 @@ using Player.Vm.Api.Data;
 namespace Player.Vm.Api.Data.Migrations.Postgres
 {
     [DbContext(typeof(VmContext))]
-    partial class ContextModelSnapshot : ModelSnapshot
+    [Migration("20220121152005_webhook_events")]
+    partial class webhook_events
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Player.Vm.Api/Data/Migrations/Postgres/20220121152005_webhook_events.cs
+++ b/src/Player.Vm.Api/Data/Migrations/Postgres/20220121152005_webhook_events.cs
@@ -1,0 +1,38 @@
+/*
+Copyright 2021 Carnegie Mellon University. All Rights Reserved. 
+ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+*/
+
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Player.Vm.Api.Data.Migrations.Postgres
+{
+    public partial class webhook_events : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "webhook_events",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "uuid_generate_v4()"),
+                    type = table.Column<int>(type: "integer", nullable: false),
+                    timestamp = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    payload = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_webhook_events", x => x.id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "webhook_events");
+        }
+    }
+}

--- a/src/Player.Vm.Api/Data/VmContext.cs
+++ b/src/Player.Vm.Api/Data/VmContext.cs
@@ -2,6 +2,7 @@
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal;
 using Player.Vm.Api.Domain.Models;
 using Player.Vm.Api.Infrastructure.Extensions;
@@ -22,6 +23,7 @@ namespace Player.Vm.Api.Data
         public DbSet<Team> Teams { get; set; }
         public DbSet<VmTeam> VmTeams { get; set; }
         public DbSet<VmMap> Maps { get; set; }
+        public DbSet<Player.Api.Client.WebhookEvent> WebhookEvents { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/src/Player.Vm.Api/Domain/Models/Coordinate.cs
+++ b/src/Player.Vm.Api/Domain/Models/Coordinate.cs
@@ -25,5 +25,12 @@ namespace Player.Vm.Api.Domain.Models
         public string[] Urls { get; set; }
 
         public string Label { get; set; }
+
+        public Coordinate Clone()
+        {
+            var clone = this.MemberwiseClone() as Coordinate;
+            clone.Id = Guid.Empty;
+            return clone;
+        }
     }
 }

--- a/src/Player.Vm.Api/Domain/Models/VmMap.cs
+++ b/src/Player.Vm.Api/Domain/Models/VmMap.cs
@@ -10,7 +10,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Player.Vm.Api.Domain.Models
 {
-    public class VmMap 
+    public class VmMap
     {
         [Key]
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
@@ -20,5 +20,17 @@ namespace Player.Vm.Api.Domain.Models
         public string Name { get; set; }
         public string ImageUrl { get; set; }
         public List<Guid> TeamIds { get; set; }
+
+        public VmMap Clone()
+        {
+            var clone = this.MemberwiseClone() as VmMap;
+            clone.Id = Guid.Empty;
+            clone.Coordinates = new List<Coordinate>();
+            foreach (var coord in this.Coordinates)
+            {
+                clone.Coordinates.Add(coord.Clone());
+            }
+            return clone;
+        }
     }
 }

--- a/src/Player.Vm.Api/Domain/Services/CallbackBackgroundService.cs
+++ b/src/Player.Vm.Api/Domain/Services/CallbackBackgroundService.cs
@@ -1,0 +1,248 @@
+// Copyright 2021 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+using AutoMapper;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using Player.Api.Client;
+using Player.Vm.Api.Data;
+using Player.Vm.Api.Features.Vms;
+using Player.Vm.Api.Infrastructure.Options;
+
+namespace Player.Vm.Api.Domain.Services;
+
+public interface ICallbackBackgroundService
+{
+    Task AddEvent(WebhookEvent e);
+}
+
+public class CallbackBackgroundService : BackgroundService, ICallbackBackgroundService
+{
+    private ActionBlock<WebhookEventWrapper> _eventQueue;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IMapper _mapper;
+    private readonly ILogger<CallbackBackgroundService> _logger;
+    private readonly IHttpClientFactory _clientFactory;
+    private readonly IOptionsMonitor<ClientOptions> _clientOptions;
+
+    public CallbackBackgroundService(
+        IServiceScopeFactory scopeFactory,
+        IMapper mapper,
+        ILogger<CallbackBackgroundService> logger,
+        IHttpClientFactory clientFactory,
+        IOptionsMonitor<ClientOptions> clientOptions)
+    {
+        _scopeFactory = scopeFactory;
+        _mapper = mapper;
+        _logger = logger;
+        _clientFactory = clientFactory;
+        _clientOptions = clientOptions;
+        _eventQueue = new ActionBlock<WebhookEventWrapper>(async e => await ProcessEvent(e));
+    }
+
+    protected async override Task ExecuteAsync(CancellationToken ct)
+    {
+        // Add any pending events in the db to send queue
+        using var scope = _scopeFactory.CreateScope();
+
+        var context = scope.ServiceProvider.GetRequiredService<VmContext>();
+        var events = await context.WebhookEvents
+            .OrderBy(x => x.Timestamp)
+            .ToListAsync(ct);
+
+        foreach (var evt in events)
+        {
+            await AddEvent(evt);
+        }
+    }
+
+    public async Task AddEvent(WebhookEvent e)
+    {
+        await _eventQueue.SendAsync(new WebhookEventWrapper(e));
+    }
+
+    private async Task AddEvent(WebhookEventWrapper e)
+    {
+        e.Attempts++;
+        await _eventQueue.SendAsync(e);
+    }
+
+    private async Task ProcessEvent(WebhookEventWrapper e)
+    {
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<VmContext>();
+
+            // Don't process if event is expired
+            if (!e.IsExpired())
+            {
+                switch (e.WebhookEvent.Type)
+                {
+                    case EventType.ViewCreated:
+                        // Since payload field is of type object, the json serialization in player makes it into string containing json
+                        var payloadCreate = JsonConvert.DeserializeObject<ViewCreated>(e.WebhookEvent.Payload.ToString());
+                        await CloneMaps(payloadCreate, dbContext);
+                        break;
+                    case EventType.ViewDeleted:
+                        var payloadDelete = JsonConvert.DeserializeObject<ViewDeleted>(e.WebhookEvent.Payload.ToString());
+                        await DeleteClonedMaps(payloadDelete.ViewId, dbContext);
+                        break;
+                }
+            }
+
+            // if no exceptions, remove this event from the db so we don't process it again
+            dbContext.WebhookEvents.Remove(e.WebhookEvent);
+            await dbContext.SaveChangesAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, $"Exception processing event with Id = {e.WebhookEvent?.Id}");
+
+            // Add back to queue after a delay to retry
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(new TimeSpan(0, 0, e.GetRetryDelaySeconds()));
+                await AddEvent(e);
+            });
+        }
+    }
+
+    private async Task CloneMaps(ViewCreated form, VmContext dbContext)
+    {
+        if (!form.ParentId.HasValue)
+        {
+            return;
+        }
+
+        var client = _clientFactory.CreateClient("player-admin");
+        client.BaseAddress = new Uri(_clientOptions.CurrentValue.urls.playerApi);
+        var playerClient = new PlayerApiClient(client);
+
+        // Get maps assigned to parent view
+        var maps = await dbContext.Maps
+            .Where(m => m.ViewId == form.ParentId)
+            .Include(m => m.Coordinates)
+            .ToListAsync();
+
+        if (maps.Count == 0)
+        {
+            return;
+        }
+
+        HashSet<Team> parentTeams = new HashSet<Team>();
+        HashSet<Team> childTeams = new HashSet<Team>();
+
+        // Views can't have duplicate teams, so use HashSet for constant time lookups
+        try
+        {
+            parentTeams = (await playerClient.GetViewTeamsAsync(form.ParentId.Value)).ToHashSet();
+            childTeams = (await playerClient.GetViewTeamsAsync(form.ViewId)).ToHashSet();
+        }
+        catch (ApiException ex)
+        {
+            // View no longer exists, so there is nothing to clone
+            if (ex.StatusCode == (int)HttpStatusCode.NotFound)
+            {
+                return;
+            }
+        }
+
+        var clonedMaps = new List<VmMap>();
+
+        // Create clones of maps assigned to the child view
+        foreach (var map in maps)
+        {
+            var clone = map.Clone();
+            clone.ViewId = form.ViewId;
+
+            var teamNames = parentTeams
+                .Where(t => map.TeamIds.Contains((Guid)t.Id))
+                .Select(t => t.Name);
+
+            var cloneTeamIds = childTeams
+                .Where(t => teamNames.Contains(t.Name))
+                .Select(t => (Guid)t.Id);
+
+            clone.TeamIds = cloneTeamIds.ToList();
+
+            dbContext.Maps.Add(clone);
+        }
+
+        await dbContext.SaveChangesAsync();
+    }
+
+    // Delete all maps associated with the deleted view
+    private async Task DeleteClonedMaps(Guid viewId, VmContext dbContext)
+    {
+        var toDelete = await dbContext.Maps
+            .Where(m => m.ViewId == viewId)
+            .Include(m => m.Coordinates)
+            .ToListAsync();
+
+        foreach (var map in toDelete)
+        {
+            foreach (var coord in map.Coordinates)
+            {
+                dbContext.Remove(coord);
+            }
+
+            dbContext.Remove(map);
+        }
+
+        await dbContext.SaveChangesAsync();
+    }
+
+    private class WebhookEventWrapper
+    {
+        private const int ExpirationHours = 48;
+        private const int InitialRetryDelaySeconds = 5;
+        private const int IncrementRetryDelaySeconds = 5;
+        private const int MaximumRetryDelaySeconds = 120;
+
+        public WebhookEventWrapper(WebhookEvent e)
+        {
+            WebhookEvent = e;
+        }
+
+        public WebhookEvent WebhookEvent { get; }
+        public bool FirstAttempt
+        {
+            get
+            {
+                return Attempts == 0;
+            }
+        }
+
+        public int Attempts { get; set; }
+
+        public bool IsExpired()
+        {
+            return !FirstAttempt && DateTime.UtcNow > WebhookEvent.Timestamp.AddHours(ExpirationHours);
+        }
+
+        public int GetRetryDelaySeconds()
+        {
+            var delay = InitialRetryDelaySeconds + (Attempts * IncrementRetryDelaySeconds);
+
+            if (delay > MaximumRetryDelaySeconds)
+            {
+                delay = MaximumRetryDelaySeconds;
+            }
+
+            return delay;
+        }
+    }
+}

--- a/src/Player.Vm.Api/Domain/Services/PlayerService.cs
+++ b/src/Player.Vm.Api/Domain/Services/PlayerService.cs
@@ -38,7 +38,14 @@ namespace Player.Vm.Api.Domain.Services
         public PlayerService(IHttpContextAccessor httpContextAccessor, IPlayerApiClient playerApiClient)
         {
             _teamCache = new Dictionary<Guid, Team>();
-            _userId = httpContextAccessor.HttpContext.User.GetId();
+            try
+            {
+                _userId = httpContextAccessor.HttpContext.User.GetId();
+            }
+            catch (Exception)
+            {
+                _userId = Guid.Empty;
+            }
             _playerApiClient = playerApiClient;
         }
 

--- a/src/Player.Vm.Api/Features/Callbacks/CallbackController.cs
+++ b/src/Player.Vm.Api/Features/Callbacks/CallbackController.cs
@@ -1,0 +1,46 @@
+// Copyright 2021 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Swashbuckle.AspNetCore.Annotations;
+using Player.Api.Client;
+using Microsoft.AspNetCore.Authorization;
+using Player.Vm.Api.Infrastructure.Constants;
+using MediatR;
+
+namespace Player.Vm.Api.Features.Callbacks
+{
+    [Authorize(Constants.PrivilegedAuthorizationPolicy)]
+    public class CallbacksController : ControllerBase
+    {
+        private readonly IMediator _mediator;
+
+        public CallbacksController(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+
+        /// <summary>
+        /// Receive a webhook event
+        /// </summary>
+        /// <param name="evt"></param>
+        /// <param name="ct"></param>
+        [HttpPost("api/callback")]
+        [ProducesResponseType((int)HttpStatusCode.Accepted)]
+        [SwaggerOperation(OperationId = "handleCallback")]
+        public async Task<IActionResult> Handle([FromBody] WebhookEvent evt, CancellationToken ct)
+        {
+            if (await _mediator.Send(new HandleCallback.Command { CallbackEvent = evt }))
+            {
+                return Accepted();
+            }
+            else
+            {
+                return Problem(statusCode: (int)HttpStatusCode.InternalServerError);
+            }
+        }
+    }
+}

--- a/src/Player.Vm.Api/Features/Callbacks/Commands/HandleCallback.cs
+++ b/src/Player.Vm.Api/Features/Callbacks/Commands/HandleCallback.cs
@@ -1,0 +1,49 @@
+// Copyright 2021 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Player.Vm.Api.Domain.Services;
+using Player.Api.Client;
+using Player.Vm.Api.Data;
+
+namespace Player.Vm.Api.Features.Callbacks
+{
+    public class HandleCallback
+    {
+        public class Command : IRequest<bool>
+        {
+            public WebhookEvent CallbackEvent { get; set; }
+        }
+
+        public class Handler : IRequestHandler<Command, bool>
+        {
+            private readonly VmContext _context;
+            private readonly ICallbackBackgroundService _callbackBackgroundService;
+
+            public Handler(
+                VmContext context,
+                ICallbackBackgroundService callbackBackgroundService)
+            {
+                _context = context;
+                _callbackBackgroundService = callbackBackgroundService;
+            }
+
+
+            public async Task<bool> Handle(Command request, CancellationToken cancellationToken)
+            {
+                await _context.WebhookEvents.AddAsync(request.CallbackEvent);
+                if (await _context.SaveChangesAsync() > 0)
+                {
+                    await _callbackBackgroundService.AddEvent(request.CallbackEvent);
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        }
+    }
+}

--- a/src/Player.Vm.Api/Features/Vms/Hubs/ProgressHub.cs
+++ b/src/Player.Vm.Api/Features/Vms/Hubs/ProgressHub.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 
 namespace Player.Vm.Api.Features.Vms.Hubs
 {
-    [Authorize(AuthenticationSchemes = "Bearer")]
     public class ProgressHub : Hub
     {
         public ProgressHub()

--- a/src/Player.Vm.Api/Features/Vms/Hubs/VmHub.cs
+++ b/src/Player.Vm.Api/Features/Vms/Hubs/VmHub.cs
@@ -14,7 +14,6 @@ using Player.Api.Client;
 
 namespace Player.Vm.Api.Features.Vms.Hubs
 {
-    [Authorize(AuthenticationSchemes = "Bearer")]
     public class VmHub : Hub
     {
         private readonly IPlayerService _playerService;

--- a/src/Player.Vm.Api/Features/Vms/VmService.cs
+++ b/src/Player.Vm.Api/Features/Vms/VmService.cs
@@ -2,20 +2,16 @@
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
 using AutoMapper;
-using AutoMapper.QueryableExtensions;
 using Microsoft.EntityFrameworkCore;
 using Player.Vm.Api.Data;
 using Player.Vm.Api.Domain.Services;
-using Player.Vm.Api.Features.Vms;
 using Player.Vm.Api.Infrastructure.Exceptions;
 using Player.Vm.Api.Infrastructure.Extensions;
-using Player.Vm.Api.Infrastructure.Options;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Security.Principal;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/Player.Vm.Api/Infrastructure/Constants/Constants.cs
+++ b/src/Player.Vm.Api/Infrastructure/Constants/Constants.cs
@@ -1,0 +1,10 @@
+// Copyright 2021 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+namespace Player.Vm.Api.Infrastructure.Constants
+{
+    public static class Constants
+    {
+        public const string PrivilegedAuthorizationPolicy = "Privileged";
+    }
+}

--- a/src/Player.Vm.Api/Infrastructure/Options/AuthorizationOptions.cs
+++ b/src/Player.Vm.Api/Infrastructure/Options/AuthorizationOptions.cs
@@ -9,6 +9,7 @@ namespace Player.Vm.Api.Infrastructure.Options
         public string AuthorizationUrl { get; set; }
         public string TokenUrl { get; set; }
         public string AuthorizationScope { get; set; }
+        public string PrivilegedScope { get; set; }
         public string ClientId { get; set; }
         public string ClientName { get; set; }
         public string ClientSecret { get; set; }

--- a/src/Player.Vm.Api/Player.Vm.Api.csproj
+++ b/src/Player.Vm.Api/Player.Vm.Api.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
     <PackageReference Include="Microsoft.OpenApi" Version="1.2.3" />
-    <PackageReference Include="Player.Api.Client" Version="1.7.1" />
+    <PackageReference Include="Player.Api.Client" Version="1.8.0" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
     <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.1">
@@ -20,15 +20,15 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.1" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.1" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.2" />
     <PackageReference Include="NetVimClient" Version="6.7.0" />
     <PackageReference Include="MediatR" Version="9.0.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
-    <PackageReference Include="Polly" Version="7.2.2" />
+    <PackageReference Include="Polly" Version="7.2.3" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.1" />
-    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.1-rc2.3"/>
-    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="6.0.1-rc2.7"/>
-    <PackageReference Include="AspNetCore.HealthChecks.Sqlite" Version="6.0.1-rc2.2"/>
+    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="6.0.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.Sqlite" Version="6.0.1" />
   </ItemGroup>
 </Project>

--- a/src/Player.Vm.Api/Startup.cs
+++ b/src/Player.Vm.Api/Startup.cs
@@ -1,13 +1,11 @@
 // Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
-using System;
 using System.IdentityModel.Tokens.Jwt;
 using System.Reflection;
 using System.Security.Principal;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
-using AutoMapper;
 using MediatR;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
@@ -16,7 +14,6 @@ using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
-using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -37,6 +34,7 @@ using Player.Vm.Api.Infrastructure.Exceptions.Middleware;
 using Player.Vm.Api.Infrastructure.Extensions;
 using Player.Vm.Api.Infrastructure.Options;
 using AuthorizationOptions = Player.Vm.Api.Infrastructure.Options.AuthorizationOptions;
+using Player.Vm.Api.Infrastructure.Constants;
 
 namespace Player.Vm.Api
 {
@@ -53,9 +51,9 @@ namespace Player.Vm.Api
         public Startup(IConfiguration configuration)
         {
             Configuration = configuration;
-            Configuration.GetSection("Authorization").Bind(_authOptions);
-            Configuration.GetSection("ClientSettings").Bind(_clientOptions);
-            Configuration.GetSection("IdentityClient").Bind(_identityClientOptions);
+            Configuration.Bind("ClientSettings", _clientOptions);
+            Configuration.Bind("IdentityClient", _identityClientOptions);
+            Configuration.Bind("Authorization", _authOptions);
             _pathbase = Configuration["PathBase"];
         }
 
@@ -138,20 +136,28 @@ namespace Player.Vm.Api
                 .AddScoped(config => config.GetService<IOptionsSnapshot<ConsoleUrlOptions>>().Value);
 
             services.AddCors(options => options.UseConfiguredCors(Configuration.GetSection("CorsPolicy")));
-            services.AddMvc(options =>
+            services.AddMvc()
+                .AddJsonOptions(options =>
+                {
+                    options.JsonSerializerOptions.PropertyNameCaseInsensitive = true;
+                    options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+                });
+
+            services.AddAuthorization(options =>
             {
-                // Require all scopes in authOptions
                 var policyBuilder = new AuthorizationPolicyBuilder().RequireAuthenticatedUser();
-                Array.ForEach(_authOptions.AuthorizationScope.Split(' '), x => policyBuilder.RequireScope(x));
 
-                var policy = policyBuilder.Build();
-                options.Filters.Add(new AuthorizeFilter(policy));
+                foreach (var scope in _authOptions.AuthorizationScope.Split(' '))
+                {
+                    policyBuilder.RequireScope(scope);
+                }
 
-            })
-            .AddJsonOptions(options =>
-            {
-                options.JsonSerializerOptions.PropertyNameCaseInsensitive = true;
-                options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+                options.DefaultPolicy = policyBuilder.Build();
+
+                options.AddPolicy(Constants.PrivilegedAuthorizationPolicy, builder => builder
+                    .RequireAuthenticatedUser()
+                    .RequireScope(_authOptions.PrivilegedScope)
+                );
             });
 
             services.AddSignalR()
@@ -180,8 +186,8 @@ namespace Player.Vm.Api
                 options.SaveToken = true;
                 options.TokenValidationParameters = new Microsoft.IdentityModel.Tokens.TokenValidationParameters
                 {
-                    ValidateIssuer = true,
-                    ValidAudiences = _authOptions.AuthorizationScope.Split(' ')
+                    ValidateAudience = false,
+                    ValidateIssuer = true
                 };
 
                 options.Events = new JwtBearerEvents
@@ -215,6 +221,9 @@ namespace Player.Vm.Api
             services.AddScoped<IPlayerService, PlayerService>();
             services.AddScoped<IViewService, ViewService>();
             services.AddScoped<IPermissionsService, PermissionsService>();
+            services.AddSingleton<CallbackBackgroundService>();
+            services.AddSingleton<IHostedService>(x => x.GetService<CallbackBackgroundService>());
+            services.AddSingleton<ICallbackBackgroundService>(x => x.GetService<CallbackBackgroundService>());
             services.AddSingleton<IAuthenticationService, AuthenticationService>();
             services.AddSingleton<IActiveVirtualMachineService, ActiveVirtualMachineService>();
 
@@ -248,6 +257,7 @@ namespace Player.Vm.Api
             {
                 IdentityModelEventSource.ShowPII = true;
             }
+
             app.UsePathBase(_pathbase);
             app.UseCustomExceptionHandler();
             app.UseRouting();
@@ -258,6 +268,9 @@ namespace Player.Vm.Api
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllers();
+                endpoints.MapHub<ProgressHub>("/hubs/progress").RequireAuthorization();
+                endpoints.MapHub<VmHub>("/hubs/vm").RequireAuthorization();
+
                 endpoints.MapHealthChecks($"/{_routePrefix}/health/ready", new HealthCheckOptions()
                 {
                     Predicate = (check) => check.Tags.Contains("ready"),
@@ -267,8 +280,6 @@ namespace Player.Vm.Api
                 {
                     Predicate = (check) => check.Tags.Contains("live"),
                 });
-                endpoints.MapHub<ProgressHub>("/hubs/progress");
-                endpoints.MapHub<VmHub>("/hubs/vm");
             });
 
             app.UseSwagger();

--- a/src/Player.Vm.Api/appsettings.json
+++ b/src/Player.Vm.Api/appsettings.json
@@ -44,6 +44,7 @@
     "AuthorizationUrl": "http://localhost:5000/connect/authorize",
     "TokenUrl": "http://localhost:5000/connect/token",
     "AuthorizationScope": "player player-vm",
+    "PrivilegedScope": "player-vm-privileged",
     "ClientId": "player.vm.swagger",
     "ClientName": "Player VM Swagger UI",
     "ClientSecret": "",


### PR DESCRIPTION
- adds callback endpoints for receiving webhook events from the Player Api
  - adds a PrivilegedScope setting that will allow any client token containing the scope
access to the webhook callback endpoints

Extends and replaces #17 

Co-authored-by: Ben Young <72205768+sei-byoung@users.noreply.github.com>
Co-authored-by: Andrew Schlackman <72105194+sei-aschlackman@users.noreply.github.com>