### PR TITLE
improve support for different identity providers

### DIFF
--- a/src/Player.Vm.Api/Infrastructure/ClaimsTransformers/ClaimsTransformer.cs
+++ b/src/Player.Vm.Api/Infrastructure/ClaimsTransformers/ClaimsTransformer.cs
@@ -1,0 +1,19 @@
+// Copyright 2021 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+using Microsoft.AspNetCore.Authentication;
+using Player.Vm.Api.Infrastructure.Extensions;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace Player.Vm.Api.Infrastructure.ClaimsTransformers
+{
+    class ClaimsTransformer : IClaimsTransformation
+    {
+        public async Task<ClaimsPrincipal> TransformAsync(ClaimsPrincipal principal)
+        {
+            var user = principal.NormalizeScopeClaims();
+            return user;
+        }
+    }
+}

--- a/src/Player.Vm.Api/Infrastructure/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/Player.Vm.Api/Infrastructure/Extensions/ClaimsPrincipalExtensions.cs
@@ -3,6 +3,7 @@
 
 
 using System;
+using System.Collections.Generic;
 using System.Security.Claims;
 
 namespace Player.Vm.Api.Infrastructure.Extensions
@@ -17,6 +18,47 @@ namespace Player.Vm.Api.Infrastructure.Extensions
         public static string GetName(this ClaimsPrincipal principal)
         {
             return principal.FindFirst("name")?.Value;
+        }
+
+        /// <summary>
+        /// Normalize scope claims to handle array or single string
+        /// </summary>
+        public static ClaimsPrincipal NormalizeScopeClaims(this ClaimsPrincipal principal)
+        {
+            var identities = new List<ClaimsIdentity>();
+
+            foreach (var id in principal.Identities)
+            {
+                var identity = new ClaimsIdentity(id.AuthenticationType, id.NameClaimType, id.RoleClaimType);
+
+                foreach (var claim in id.Claims)
+                {
+                    if (claim.Type == "scope")
+                    {
+                        if (claim.Value.Contains(' '))
+                        {
+                            var scopes = claim.Value.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+                            foreach (var scope in scopes)
+                            {
+                                identity.AddClaim(new Claim("scope", scope, claim.ValueType, claim.Issuer));
+                            }
+                        }
+                        else
+                        {
+                            identity.AddClaim(claim);
+                        }
+                    }
+                    else
+                    {
+                        identity.AddClaim(claim);
+                    }
+                }
+
+                identities.Add(identity);
+            }
+
+            return new ClaimsPrincipal(identities);
         }
     }
 }

--- a/src/Player.Vm.Api/Infrastructure/Options/AuthorizationOptions.cs
+++ b/src/Player.Vm.Api/Infrastructure/Options/AuthorizationOptions.cs
@@ -14,5 +14,7 @@ namespace Player.Vm.Api.Infrastructure.Options
         public string ClientName { get; set; }
         public string ClientSecret { get; set; }
         public bool RequireHttpsMetadata { get; set; }
+        public bool ValidateAudience { get; set; }
+        public string[] ValidAudiences { get; set; }
     }
 }

--- a/src/Player.Vm.Api/appsettings.json
+++ b/src/Player.Vm.Api/appsettings.json
@@ -48,7 +48,9 @@
     "ClientId": "player.vm.swagger",
     "ClientName": "Player VM Swagger UI",
     "ClientSecret": "",
-    "RequireHttpsMetadata": false
+    "RequireHttpsMetadata": false,
+    "ValidateAudience": true,
+    "ValidAudiences": [] // Defaults to AuthorizationScope + PrivilegedScope if null or empty
   },
   "IsoUpload": {
     "BasePath": "player/isos",
@@ -93,6 +95,6 @@
   },
   "VmUsageLogging": {
     "Enabled": "false",
-    "PostgreSQL": "Server=localhost;Port=5432;Database=vm_logging;Username=postgres;Password=password;",
+    "PostgreSQL": "Server=localhost;Port=5432;Database=vm_logging;Username=postgres;Password=password;"
   }
 }


### PR DESCRIPTION
- support scope claims as array or single space-delimited string
- adds ValidateAudience and ValidAudiences settings
  - allows for more granular control of token validation settings
  - defaults to previous behavior