### PR TITLE
fix vm power state not always updating

### DIFF
--- a/src/Player.Vm.Api/Domain/Vsphere/Services/MachineStateService.cs
+++ b/src/Player.Vm.Api/Domain/Vsphere/Services/MachineStateService.cs
@@ -82,7 +82,7 @@ namespace Player.Vm.Api.Domain.Vsphere.Services
                 }
 
                 await _resetEvent.WaitAsync(
-                    new TimeSpan(0, 0, 0, _options.CheckTaskProgressIntervalMilliseconds),
+                    new TimeSpan(0, 0, 0, 0, _options.CheckTaskProgressIntervalMilliseconds),
                     cancellationToken);
             }
         }
@@ -131,7 +131,7 @@ namespace Player.Vm.Api.Domain.Vsphere.Services
                 return;
             }
 
-            var filteredEvents = events.GroupBy(x => x.vm.vm)
+            var filteredEvents = events.GroupBy(x => x.vm.vm.Value)
                 .Select(g => g.OrderByDescending(l => l.createdTime).First())
                 .ToArray();
 
@@ -141,7 +141,7 @@ namespace Player.Vm.Api.Domain.Vsphere.Services
 
                 if (id.HasValue)
                 {
-                    eventDict.Add(id.Value, evt);
+                    eventDict.TryAdd(id.Value, evt);
                 }
             }
 

--- a/src/Player.Vm.Api/appsettings.json
+++ b/src/Player.Vm.Api/appsettings.json
@@ -99,7 +99,7 @@
     }
   },
   "VmUsageLogging": {
-    "Enabled": "false",
+    "Enabled": false,
     "PostgreSQL": "Server=localhost;Port=5432;Database=vm_logging;Username=postgres;Password=password;"
   },
   "Proxmox": {


### PR DESCRIPTION
- fixed MachineStateService timer being inadvertantly set to seconds rather than milliseconds
- fixed check to filter for only the most recent power event for each vm