### PR TITLE
fixed race condition when adding vms

### DIFF
--- a/src/Player.Vm.Api/Data/Migrations/Postgres/20230412145611_vmteam_fix.Designer.cs
+++ b/src/Player.Vm.Api/Data/Migrations/Postgres/20230412145611_vmteam_fix.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Player.Vm.Api.Data;
@@ -12,9 +13,10 @@ using Player.Vm.Api.Data;
 namespace Player.Vm.Api.Data.Migrations.Postgres
 {
     [DbContext(typeof(VmContext))]
-    partial class ContextModelSnapshot : ModelSnapshot
+    [Migration("20230412145611_vmteam_fix")]
+    partial class vmteam_fix
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Player.Vm.Api/Data/Migrations/Postgres/20230412145611_vmteam_fix.cs
+++ b/src/Player.Vm.Api/Data/Migrations/Postgres/20230412145611_vmteam_fix.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Player.Vm.Api.Data.Migrations.Postgres
+{
+    public partial class vmteam_fix : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_vm_teams_teams_team_id",
+                table: "vm_teams");
+
+            migrationBuilder.DropTable(
+                name: "teams");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "teams",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "uuid_generate_v4()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_teams", x => x.id);
+                });
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_vm_teams_teams_team_id",
+                table: "vm_teams",
+                column: "team_id",
+                principalTable: "teams",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/src/Player.Vm.Api/Data/VmContext.cs
+++ b/src/Player.Vm.Api/Data/VmContext.cs
@@ -20,7 +20,6 @@ namespace Player.Vm.Api.Data
         }
 
         public DbSet<Domain.Models.Vm> Vms { get; set; }
-        public DbSet<Team> Teams { get; set; }
         public DbSet<VmTeam> VmTeams { get; set; }
         public DbSet<VmMap> Maps { get; set; }
         public DbSet<Player.Api.Client.WebhookEvent> WebhookEvents { get; set; }

--- a/src/Player.Vm.Api/Domain/Models/VmTeam.cs
+++ b/src/Player.Vm.Api/Domain/Models/VmTeam.cs
@@ -18,7 +18,6 @@ namespace Player.Vm.Api.Domain.Models
         }
 
         public Guid TeamId { get; set; }
-        public virtual Team Team { get; set; }
 
         public Guid VmId { get; set; }
         public virtual Vm Vm { get; set; }
@@ -29,11 +28,6 @@ namespace Player.Vm.Api.Domain.Models
         public void Configure(EntityTypeBuilder<VmTeam> builder)
         {
             builder.HasKey(e => new { e.TeamId, e.VmId });
-
-            builder
-                .HasOne(tu => tu.Team)
-                .WithMany(t => t.VmTeams)
-                .HasForeignKey(tu => tu.TeamId);
 
             builder
                 .HasOne(tu => tu.Vm)

--- a/src/Player.Vm.Api/Features/Vms/VmService.cs
+++ b/src/Player.Vm.Api/Features/Vms/VmService.cs
@@ -237,19 +237,6 @@ namespace Player.Vm.Api.Features.Vms
             if (!(await _permissionsService.CanWrite(formTeams, ct)))
                 throw new ForbiddenException();
 
-            var teamList = await _context.Teams
-                .Where(t => formTeams.Contains(t.Id))
-                .Select(t => t.Id)
-                .ToListAsync(ct);
-
-            foreach (var vmTeam in vmEntity.VmTeams)
-            {
-                if (!teamList.Contains(vmTeam.TeamId))
-                {
-                    _context.Teams.Add(new Domain.Models.Team() { Id = vmTeam.TeamId });
-                }
-            }
-
             _context.Vms.Add(vmEntity);
             await _context.SaveChangesAsync(ct);
 
@@ -315,14 +302,6 @@ namespace Player.Vm.Api.Features.Vms
 
             if (!(await _permissionsService.CanWrite(new[] { teamId }, ct)))
                 throw new ForbiddenException();
-
-            var team = await _context.Teams.SingleOrDefaultAsync(t => t.Id == teamId, ct);
-
-            if (team == null)
-            {
-                Domain.Models.Team te = new Domain.Models.Team { Id = teamId };
-                _context.Teams.Add(te);
-            }
 
             var vmteam = await _context.VmTeams.SingleOrDefaultAsync(vt => vt.VmId == vmId && vt.TeamId == teamId);
 


### PR DESCRIPTION
- removed unused teams table and foreign key constraint from vm_teams
  - team id's are references to player api teams so there is no value in maintaining our own table of just the ids here
  - removes the need to add new teams to the local table, which was causing duplicate key errors when adding multiple vms in some cases