### PR TITLE
Return null instead of throwing when VSphere VM not found

### DIFF
--- a/src/Player.Vm.Api/Domain/Vsphere/Services/VsphereService.cs
+++ b/src/Player.Vm.Api/Domain/Vsphere/Services/VsphereService.cs
@@ -1490,6 +1490,12 @@ namespace Player.Vm.Api.Domain.Vsphere.Services
         public async Task<VsphereVirtualMachine> GetMachineById(Guid id)
         {
             var aggregate = await this.GetVm(id);
+
+            if (aggregate == null)
+            {
+                return null;
+            }
+
             var machineReference = aggregate.MachineReference;
 
             // retrieve all machine properties we need


### PR DESCRIPTION
VsphereService.GetMachineById now returns null when VM doesn't exist in VMware infrastructure instead of throwing NullReferenceException. This allows Unknown type VMs to gracefully fail when queried for VSphere details, enabling usage logging for VMs without actual VMware backing while still supporting newly created VMs that haven't been type-detected yet.