### PR TITLE
Apply Scoped Team Permissions

### DIFF
--- a/src/Player.Vm.Api/Domain/Services/PlayerService.cs
+++ b/src/Player.Vm.Api/Domain/Services/PlayerService.cs
@@ -19,6 +19,9 @@ namespace Player.Vm.Api.Domain.Services
     {
         Task<IEnumerable<Team>> GetTeamsByViewIdAsync(Guid viewId, CancellationToken ct);
         Task<Team> GetPrimaryTeamByViewIdAsync(Guid viewId, CancellationToken ct);
+        Task<VisibilityContext> GetVisibilityContextAsync(Guid viewId, CancellationToken ct);
+        Task<VisibilityContext> GetVisibilityContextForTeamAsync(Guid teamId, CancellationToken ct);
+        Task<bool> IsTeamVisibleAsync(Guid teamId, CancellationToken ct);
         Task<Guid?> GetGroupIdForViewAsync(Guid viewId, CancellationToken ct);
         Task<View> GetViewByIdAsync(Guid viewId, CancellationToken ct);
         Task<Team> GetTeamById(Guid id);
@@ -67,12 +70,24 @@ namespace Player.Vm.Api.Domain.Services
 
         public async Task<bool> CanManageTeams(IEnumerable<Guid> teamIds, CancellationToken ct)
         {
-            return await Can(teamIds, null, [AppSystemPermission.ManageViews], [AppViewPermission.ManageView], [], ct);
+            return await Can(
+                teamIds,
+                null,
+                [AppSystemPermission.ManageViews],
+                [AppViewPermission.ManageView],
+                [AppTeamPermission.ManageTeam],
+                ct);
         }
 
         public async Task<bool> CanViewTeams(IEnumerable<Guid> teamIds, CancellationToken ct)
         {
-            return await Can(teamIds, null, [AppSystemPermission.ViewViews], [AppViewPermission.ViewView], [AppTeamPermission.ViewTeam], ct);
+            return await Can(
+                teamIds,
+                null,
+                [AppSystemPermission.ViewViews, AppSystemPermission.ManageViews],
+                [AppViewPermission.ViewView, AppViewPermission.ManageView],
+                [AppTeamPermission.ViewTeam, AppTeamPermission.ManageTeam],
+                ct);
         }
 
         public async Task<bool> CanEditTeams(IEnumerable<Guid> teamIds, CancellationToken ct)
@@ -196,7 +211,8 @@ namespace Player.Vm.Api.Domain.Services
             try
             {
                 var teams = await GetUserViewTeamsByViewIdAsync(viewId, ct);
-                return teams;
+                var visibility = await GetVisibilityContextAsync(viewId, ct);
+                return teams.Where(x => visibility.TeamIds.Contains(x.Id));
             }
             catch (Player.Api.Client.ApiException ex) when (ex.StatusCode == 404)
             {
@@ -210,10 +226,8 @@ namespace Player.Vm.Api.Domain.Services
             try
             {
                 var teams = await GetUserViewTeamsByViewIdAsync(viewId, ct);
-
-                return teams
-                    .Where(t => t.IsPrimary)
-                    .FirstOrDefault();
+                var visibility = await GetVisibilityContextAsync(viewId, ct);
+                return teams.FirstOrDefault(x => x.Id == visibility.PrimaryTeamId);
             }
             catch (Player.Api.Client.ApiException ex) when (ex.StatusCode == 404)
             {
@@ -224,11 +238,11 @@ namespace Player.Vm.Api.Domain.Services
 
         public async Task<IEnumerable<Guid>> GetGroupIdsForViewAsync(Guid viewId, CancellationToken ct)
         {
-            if (await Can([], [viewId], [AppSystemPermission.ViewViews], [AppViewPermission.ViewView], [], ct))
+            var visibility = await GetVisibilityContextAsync(viewId, ct);
+            if (visibility.CanViewAllTeams)
                 return [viewId];
 
-            var teams = await GetTeamsByViewIdAsync(viewId, ct);
-            return teams?.Select(x => x.Id).Distinct().ToArray() ?? [];
+            return visibility.TeamIds;
         }
 
         public async Task<Team> GetTeamById(Guid id)
@@ -245,7 +259,62 @@ namespace Player.Vm.Api.Domain.Services
 
         public async Task<Guid?> GetGroupIdForViewAsync(Guid viewId, CancellationToken ct)
         {
-            return (await GetGroupIdsForViewAsync(viewId, ct)).FirstOrDefault();
+            var visibility = await GetVisibilityContextAsync(viewId, ct);
+            if (!visibility.PrimaryTeamId.HasValue)
+                return null;
+
+            if (visibility.CanViewAllTeams)
+                return viewId;
+
+            return visibility.PrimaryTeamId;
+        }
+
+        public async Task<VisibilityContext> GetVisibilityContextAsync(Guid viewId, CancellationToken ct)
+        {
+            var permissions = await GetTeamPermissionsByViewIdAsync(viewId, ct);
+            var primaryPermission = permissions.FirstOrDefault(x => x.IsPrimary);
+
+            if (primaryPermission == null)
+                return VisibilityContext.Empty;
+
+            var directViewPermissions = ParsePermissions<AppViewPermission>(primaryPermission.DirectPermissionValues);
+            var directTeamPermissions = ParsePermissions<AppTeamPermission>(primaryPermission.DirectPermissionValues);
+            var canViewAllTeams =
+                directViewPermissions.Contains(AppViewPermission.ViewView) ||
+                directViewPermissions.Contains(AppViewPermission.ManageView);
+            var visibleTeamIds = new HashSet<Guid> { primaryPermission.TeamId };
+
+            if (canViewAllTeams)
+            {
+                var teams = await GetUserViewTeamsByViewIdAsync(viewId, ct);
+                visibleTeamIds.UnionWith(teams.Select(x => x.Id));
+            }
+            else if (
+                directTeamPermissions.Contains(AppTeamPermission.ViewTeam) ||
+                directTeamPermissions.Contains(AppTeamPermission.ManageTeam))
+            {
+                visibleTeamIds.UnionWith(permissions
+                    .Where(x => x.SourceTeamIds?.Contains(primaryPermission.TeamId) ?? false)
+                    .Select(x => x.TeamId));
+            }
+
+            visibleTeamIds.Remove(Guid.Empty);
+            return new VisibilityContext(primaryPermission.TeamId, canViewAllTeams, visibleTeamIds);
+        }
+
+        public async Task<bool> IsTeamVisibleAsync(Guid teamId, CancellationToken ct)
+        {
+            var visibility = await GetVisibilityContextForTeamAsync(teamId, ct);
+            return visibility.TeamIds.Contains(teamId);
+        }
+
+        public async Task<VisibilityContext> GetVisibilityContextForTeamAsync(Guid teamId, CancellationToken ct)
+        {
+            var viewId = await _viewService.GetViewIdForTeam(teamId, ct);
+            if (!viewId.HasValue)
+                return VisibilityContext.Empty;
+
+            return await GetVisibilityContextAsync(viewId.Value, ct);
         }
 
         public async Task<View> GetViewByIdAsync(Guid viewId, CancellationToken ct)
@@ -306,6 +375,16 @@ namespace Player.Vm.Api.Domain.Services
                 .Any();
         }
 
+        private static HashSet<TPermission> ParsePermissions<TPermission>(IEnumerable<string> permissionValues)
+            where TPermission : struct, Enum
+        {
+            return (permissionValues ?? [])
+                .Select(x => Enum.TryParse<TPermission>(x, out var permission) ? permission : (TPermission?)null)
+                .Where(p => p.HasValue)
+                .Select(p => p.Value)
+                .ToHashSet();
+        }
+
         private static bool HasTeamPermission(ICollection<TeamPermissionsClaim> claims, IEnumerable<Guid> teamIds, AppTeamPermission[] requiredPermissions)
         {
             return claims
@@ -317,5 +396,21 @@ namespace Player.Vm.Api.Domain.Services
                 .Intersect(requiredPermissions)
                 .Any();
         }
+    }
+
+    public sealed class VisibilityContext
+    {
+        public static VisibilityContext Empty { get; } = new(null, false, []);
+
+        public VisibilityContext(Guid? primaryTeamId, bool canViewAllTeams, HashSet<Guid> teamIds)
+        {
+            PrimaryTeamId = primaryTeamId;
+            CanViewAllTeams = canViewAllTeams;
+            TeamIds = teamIds;
+        }
+
+        public Guid? PrimaryTeamId { get; }
+        public bool CanViewAllTeams { get; }
+        public IReadOnlySet<Guid> TeamIds { get; }
     }
 }

--- a/src/Player.Vm.Api/Domain/Services/PlayerService.cs
+++ b/src/Player.Vm.Api/Domain/Services/PlayerService.cs
@@ -25,6 +25,7 @@ namespace Player.Vm.Api.Domain.Services
         Task<User> GetUserById(Guid id, CancellationToken ct);
         Task<IEnumerable<User>> GetUsersByTeamId(Guid teamId, CancellationToken ct);
 
+        Task<IEnumerable<Guid>> GetGroupIdsForViewAsync(Guid viewId, CancellationToken ct);
         Task<bool> CanManageTeams(IEnumerable<Guid> teamIds, CancellationToken ct);
         Task<bool> CanViewTeams(IEnumerable<Guid> teamIds, CancellationToken ct);
         Task<bool> CanEditTeams(IEnumerable<Guid> teamIds, CancellationToken ct);
@@ -47,6 +48,7 @@ namespace Player.Vm.Api.Domain.Services
         private readonly IViewService _viewService;
         private readonly IMemoryCache _cache;
         private ConcurrentDictionary<Guid, ICollection<TeamPermissionsClaim>> _teamPermissionsCache = new();
+        private ConcurrentDictionary<Guid, ICollection<Team>> _viewTeamsCache = new();
 
         public PlayerService(IHttpContextAccessor httpContextAccessor, IPlayerApiClient playerApiClient, IViewService viewService, IMemoryCache cache)
         {
@@ -92,18 +94,14 @@ namespace Player.Vm.Api.Domain.Services
         {
             var userTeamIds = new List<Guid>();
 
-            foreach (var teamId in teamIds)
+            foreach (var teamId in teamIds ?? [])
             {
                 var viewId = await _viewService.GetViewIdForTeam(teamId, ct);
 
                 if (!viewId.HasValue)
                     continue;
 
-                if (!_teamPermissionsCache.TryGetValue(viewId.Value, out var teamPermissionsClaims))
-                {
-                    teamPermissionsClaims = await _playerApiClient.GetMyTeamPermissionsAsync(viewId.Value, null, true);
-                    _teamPermissionsCache.TryAdd(viewId.Value, teamPermissionsClaims);
-                }
+                var teamPermissionsClaims = await GetTeamPermissionsByViewIdAsync(viewId.Value, ct);
 
                 if (teamPermissionsClaims != null && teamPermissionsClaims.Any(x => x.TeamId == teamId))
                 {
@@ -121,6 +119,12 @@ namespace Player.Vm.Api.Domain.Services
                        AppTeamPermission[] requiredTeamPermissions,
                        CancellationToken ct)
         {
+            var requestedTeamIds = (teamIds ?? []).Where(x => x != Guid.Empty).Distinct().ToArray();
+            var requestedViewIds = (viewIds ?? []).Where(x => x != Guid.Empty).Distinct().ToArray();
+            requiredSystemPermissions ??= [];
+            requiredViewPermissions ??= [];
+            requiredTeamPermissions ??= [];
+
             ICollection<string> systemPermissions;
 
             if (!_cache.TryGetValue(_userId, out systemPermissions))
@@ -129,60 +133,57 @@ namespace Player.Vm.Api.Domain.Services
                 _cache.Set(_userId, systemPermissions, new MemoryCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromMinutes(1)));
             }
 
-            var appSystemPermissions = systemPermissions
+            var appSystemPermissions = (systemPermissions ?? [])
                 .Select(x => Enum.TryParse<AppSystemPermission>(x, out var p) ? p : (AppSystemPermission?)null)
                 .Where(p => p.HasValue)
                 .Select(p => p.Value);
 
-            if (appSystemPermissions.Intersect(requiredSystemPermissions).Any())
+            if (requiredSystemPermissions.Any() && appSystemPermissions.Intersect(requiredSystemPermissions).Any())
                 return true;
 
-            List<Guid> allViewIds = new(viewIds ?? []);
+            var teamViewIds = new Dictionary<Guid, Guid>();
 
-            if (teamIds.Any())
+            foreach (var teamId in requestedTeamIds)
             {
-                allViewIds.AddRange(await _viewService.GetViewIdsForTeams(teamIds, ct));
+                var viewId = await _viewService.GetViewIdForTeam(teamId, ct);
+
+                if (viewId.HasValue)
+                    teamViewIds[teamId] = viewId.Value;
             }
+
+            var allViewIds = requestedViewIds
+                .Concat(teamViewIds.Values)
+                .Distinct()
+                .ToArray();
 
             foreach (var viewId in allViewIds)
             {
-                if (!_teamPermissionsCache.TryGetValue(viewId, out var teamPermissionsClaims))
-                {
-                    teamPermissionsClaims = await _playerApiClient.GetMyTeamPermissionsAsync(viewId, null, true);
-                    _teamPermissionsCache.TryAdd(viewId, teamPermissionsClaims);
-                }
+                var teamPermissionsClaims = await GetTeamPermissionsByViewIdAsync(viewId, ct);
 
-                if (teamPermissionsClaims != null)
+                if (requiredViewPermissions.Any() && teamPermissionsClaims != null)
                 {
-                    // Check View Permissions of all Teams in the View
-                    var appViewPermissions = teamPermissionsClaims
-                        .SelectMany(x => x.PermissionValues)
-                        .Select(x => Enum.TryParse<AppViewPermission>(x, out var p) ? p : (AppViewPermission?)null)
-                        .Where(p => p.HasValue)
-                        .Select(p => p.Value);
+                    var targetTeamIds = teamViewIds
+                        .Where(x => x.Value == viewId)
+                        .Select(x => x.Key)
+                        .ToArray();
 
-                    if (appViewPermissions.Intersect(requiredViewPermissions).Any())
-                    {
+                    if (targetTeamIds.Any() && HasViewPermission(teamPermissionsClaims, targetTeamIds, requiredViewPermissions))
                         return true;
-                    }
+
+                    var directTeamIds = await GetDirectTeamIdsByViewIdAsync(viewId, ct);
+
+                    if (directTeamIds.Any() && HasViewPermission(teamPermissionsClaims, directTeamIds, requiredViewPermissions))
+                        return true;
                 }
-            }
 
-            foreach (var teamId in teamIds)
-            {
-                var viewId = await _viewService.GetViewIdForTeam(teamId, ct);
-                var viewPermissions = _teamPermissionsCache.Where(x => x.Key == viewId).FirstOrDefault().Value;
-                var teamPermissionClaim = viewPermissions.Where(x => x.TeamId == teamId).FirstOrDefault();
-
-                if (teamPermissionClaim != null)
+                if (requiredTeamPermissions.Any() && teamPermissionsClaims != null)
                 {
-                    // Check Team Permissions of just the specified Team
-                    var appTeamPermissions = teamPermissionClaim?.PermissionValues
-                        .Select(x => Enum.TryParse<AppTeamPermission>(x, out var p) ? p : (AppTeamPermission?)null)
-                        .Where(p => p.HasValue)
-                        .Select(p => p.Value) ?? [];
+                    var targetTeamIds = teamViewIds
+                        .Where(x => x.Value == viewId)
+                        .Select(x => x.Key)
+                        .ToArray();
 
-                    if (appTeamPermissions.Intersect(requiredTeamPermissions).Any())
+                    if (targetTeamIds.Any() && HasTeamPermission(teamPermissionsClaims, targetTeamIds, requiredTeamPermissions))
                         return true;
                 }
             }
@@ -194,7 +195,7 @@ namespace Player.Vm.Api.Domain.Services
         {
             try
             {
-                var teams = await _playerApiClient.GetUserViewTeamsAsync(viewId, _userId, ct);
+                var teams = await GetUserViewTeamsByViewIdAsync(viewId, ct);
                 return teams;
             }
             catch (Player.Api.Client.ApiException ex) when (ex.StatusCode == 404)
@@ -208,7 +209,7 @@ namespace Player.Vm.Api.Domain.Services
         {
             try
             {
-                var teams = await _playerApiClient.GetUserViewTeamsAsync(viewId, _userId, ct);
+                var teams = await GetUserViewTeamsByViewIdAsync(viewId, ct);
 
                 return teams
                     .Where(t => t.IsPrimary)
@@ -219,6 +220,15 @@ namespace Player.Vm.Api.Domain.Services
                 // View not found in Player API - return null to allow caller to handle
                 return null;
             }
+        }
+
+        public async Task<IEnumerable<Guid>> GetGroupIdsForViewAsync(Guid viewId, CancellationToken ct)
+        {
+            if (await Can([], [viewId], [AppSystemPermission.ViewViews], [AppViewPermission.ViewView], [], ct))
+                return [viewId];
+
+            var teams = await GetTeamsByViewIdAsync(viewId, ct);
+            return teams?.Select(x => x.Id).Distinct().ToArray() ?? [];
         }
 
         public async Task<Team> GetTeamById(Guid id)
@@ -235,33 +245,7 @@ namespace Player.Vm.Api.Domain.Services
 
         public async Task<Guid?> GetGroupIdForViewAsync(Guid viewId, CancellationToken ct)
         {
-            Guid? groupId = null;
-            var permissions = await _playerApiClient.GetMyTeamPermissionsAsync(viewId, null, null, ct);
-
-            if (permissions != null)
-            {
-                var appViewPermissions = permissions
-                    .SelectMany(x => x.PermissionValues)
-                    .Select(x => Enum.TryParse<AppViewPermission>(x, out var p) ? p : (AppViewPermission?)null)
-                    .Where(p => p.HasValue)
-                    .Select(p => p.Value);
-
-                if (appViewPermissions.Contains(AppViewPermission.ViewView))
-                {
-                    groupId = viewId;
-                }
-                else
-                {
-                    var primaryTeamPermissions = permissions.Where(x => x.IsPrimary).FirstOrDefault();
-
-                    if (primaryTeamPermissions != null)
-                    {
-                        groupId = primaryTeamPermissions.TeamId;
-                    }
-                }
-            }
-
-            return groupId;
+            return (await GetGroupIdsForViewAsync(viewId, ct)).FirstOrDefault();
         }
 
         public async Task<View> GetViewByIdAsync(Guid viewId, CancellationToken ct)
@@ -277,6 +261,61 @@ namespace Player.Vm.Api.Domain.Services
         public async Task<IEnumerable<User>> GetUsersByTeamId(Guid teamId, CancellationToken ct)
         {
             return await _playerApiClient.GetTeamUsersAsync(teamId, ct);
+        }
+
+        private async Task<ICollection<TeamPermissionsClaim>> GetTeamPermissionsByViewIdAsync(Guid viewId, CancellationToken ct)
+        {
+            if (!_teamPermissionsCache.TryGetValue(viewId, out var teamPermissionsClaims))
+            {
+                teamPermissionsClaims = await _playerApiClient.GetMyTeamPermissionsAsync(viewId, null, true, ct);
+                _teamPermissionsCache.TryAdd(viewId, teamPermissionsClaims);
+            }
+
+            return teamPermissionsClaims ?? [];
+        }
+
+        private async Task<ICollection<Team>> GetUserViewTeamsByViewIdAsync(Guid viewId, CancellationToken ct)
+        {
+            if (!_viewTeamsCache.TryGetValue(viewId, out var teams))
+            {
+                teams = await _playerApiClient.GetUserViewTeamsAsync(viewId, _userId, ct);
+                _viewTeamsCache.TryAdd(viewId, teams);
+            }
+
+            return teams ?? [];
+        }
+
+        private async Task<HashSet<Guid>> GetDirectTeamIdsByViewIdAsync(Guid viewId, CancellationToken ct)
+        {
+            var teams = await GetUserViewTeamsByViewIdAsync(viewId, ct);
+            return teams
+                .Where(x => x.IsMember || x.IsPrimary)
+                .Select(x => x.Id)
+                .ToHashSet();
+        }
+
+        private static bool HasViewPermission(ICollection<TeamPermissionsClaim> claims, IEnumerable<Guid> teamIds, AppViewPermission[] requiredPermissions)
+        {
+            return claims
+                .Where(x => teamIds.Contains(x.TeamId))
+                .SelectMany(x => x.PermissionValues ?? [])
+                .Select(x => Enum.TryParse<AppViewPermission>(x, out var p) ? p : (AppViewPermission?)null)
+                .Where(p => p.HasValue)
+                .Select(p => p.Value)
+                .Intersect(requiredPermissions)
+                .Any();
+        }
+
+        private static bool HasTeamPermission(ICollection<TeamPermissionsClaim> claims, IEnumerable<Guid> teamIds, AppTeamPermission[] requiredPermissions)
+        {
+            return claims
+                .Where(x => teamIds.Contains(x.TeamId))
+                .SelectMany(x => x.PermissionValues ?? [])
+                .Select(x => Enum.TryParse<AppTeamPermission>(x, out var p) ? p : (AppTeamPermission?)null)
+                .Where(p => p.HasValue)
+                .Select(p => p.Value)
+                .Intersect(requiredPermissions)
+                .Any();
         }
     }
 }

--- a/src/Player.Vm.Api/Features/Vms/Hubs/VmHub.cs
+++ b/src/Player.Vm.Api/Features/Vms/Hubs/VmHub.cs
@@ -136,17 +136,31 @@ namespace Player.Vm.Api.Features.Vms.Hubs
 
         public async Task<VmUser> JoinUser(Guid userId, Guid viewId, Guid teamId)
         {
-            if (!await _playerService.CanViewTeams([teamId], Context.ConnectionAborted))
+            var visibility = await _playerService.GetVisibilityContextAsync(viewId, Context.ConnectionAborted);
+            if (!visibility.TeamIds.Contains(teamId))
                 throw new HubException("You do not have access to this team");
 
             var activeVm = _activeVirtualMachineService.GetActiveVirtualMachineForUser(userId);
+            Guid? activeVmId = null;
+            var groupId = visibility.CanViewAllTeams ? viewId : teamId;
 
-            await Groups.AddToGroupAsync(Context.ConnectionId, GetGroup(teamId, userId));
+            await Groups.AddToGroupAsync(Context.ConnectionId, GetGroup(groupId, userId));
 
-            // Check if this team is allowed to see the target user's active VM.
-            var activeVmId = activeVm != null && activeVm.TeamIds.Contains(teamId)
-                ? activeVm.VmId
-                : (Guid?)null;
+            if (activeVm != null)
+            {
+                if (visibility.CanViewAllTeams)
+                {
+                    var activeViewIds = await _viewService.GetViewIdsForTeams(
+                        activeVm.TeamIds,
+                        Context.ConnectionAborted);
+                    if (activeViewIds.Contains(viewId))
+                        activeVmId = activeVm.VmId;
+                }
+                else if (activeVm.TeamIds.Contains(teamId))
+                {
+                    activeVmId = activeVm.VmId;
+                }
+            }
 
             var user = await _playerService.GetUserById(userId, Context.ConnectionAborted);
             var dbUser = await _dbContext.VmUsers
@@ -183,10 +197,21 @@ namespace Player.Vm.Api.Features.Vms.Hubs
 
             foreach (var viewId in viewIds)
             {
-                groupIds.UnionWith(await _playerService.GetGroupIdsForViewAsync(viewId, Context.ConnectionAborted));
+                var visibility = await _playerService.GetVisibilityContextAsync(viewId, Context.ConnectionAborted);
+                if (!vm.TeamIds.Any(visibility.TeamIds.Contains))
+                    continue;
+
+                if (visibility.CanViewAllTeams)
+                {
+                    groupIds.Add(viewId);
+                }
+                else
+                {
+                    groupIds.UnionWith(visibility.TeamIds);
+                }
             }
 
-            foreach (var groupId in groupIds.Where(x => viewIds.Contains(x) || vm.TeamIds.Contains(x)))
+            foreach (var groupId in groupIds)
             {
                 if (join)
                 {
@@ -207,21 +232,25 @@ namespace Player.Vm.Api.Features.Vms.Hubs
 
             var viewIds = await _viewService.GetViewIdsForTeams(vm.TeamIds, Context.ConnectionAborted);
 
-            var teams = new List<Team>();
+            var teamIds = new HashSet<Guid>();
+            var visibleViewIds = new HashSet<Guid>();
 
             foreach (var viewId in viewIds)
             {
-                var primaryTeam = await _playerService.GetPrimaryTeamByViewIdAsync(viewId, Context.ConnectionAborted);
+                var visibility = await _playerService.GetVisibilityContextAsync(viewId, Context.ConnectionAborted);
 
-                if (primaryTeam != null)
+                if (visibility.PrimaryTeamId.HasValue &&
+                    vm.TeamIds.Any(visibility.TeamIds.Contains))
                 {
-                    teams.Add(primaryTeam);
+                    teamIds.Add(visibility.PrimaryTeamId.Value);
+                    visibleViewIds.Add(viewId);
                 }
             }
 
-            var teamIds = teams.Select(x => x.Id);
-            var groups = GetGroups(teams.Select(x => x.Id), viewIds, userId, vmId);
+            var groups = GetGroups(teamIds, visibleViewIds, userId, vmId);
 
+            // Presence remains scoped to the user's primary/view context so elevated
+            // VM access does not expose a non-member user to a team.
             var newVmId = await _activeVirtualMachineService.SetActiveVirtualMachineForUser(userId, Context.User.GetName(), vm, Context.ConnectionId, teamIds, Context.ConnectionAborted);
 
             await Clients.Groups(groups).SendAsync(VmHubMethods.ActiveVirtualMachine, newVmId, userId, DateTimeOffset.UtcNow, teamIds);
@@ -231,11 +260,15 @@ namespace Player.Vm.Api.Features.Vms.Hubs
 
             foreach (var kvp in userNamesByGroup)
             {
-                await Clients.Groups(GetCurrentVmUsersChannelName(kvp.Key, vmId)).SendAsync(VmHubMethods.CurrentVirtualMachineUsers, vmId, kvp.Value);
+                await Clients.Groups(GetCurrentVmUsersChannelName(kvp.Key, vmId)).SendAsync(
+                    VmHubMethods.CurrentVirtualMachineUsers,
+                    vmId,
+                    kvp.Value,
+                    kvp.Key);
             }
 
             await _vmUsageLoggingService.CreateVmLogEntry(userId, vmId, teamIds, CancellationToken.None);
-            await UpdateVmUser(userId, vmId, teams.Select(x => x.Id));
+            await UpdateVmUser(userId, vmId, teamIds);
         }
 
         public async Task UnsetActiveVirtualMachine()
@@ -259,27 +292,24 @@ namespace Player.Vm.Api.Features.Vms.Hubs
             {
                 var viewIds = await _viewService.GetViewIdsForTeams(activeVirtualMachine.TeamIds, cancellationToken);
 
-                var teams = new List<Team>();
-
-                foreach (var viewId in viewIds)
-                {
-                    var primaryTeam = await _playerService.GetPrimaryTeamByViewIdAsync(viewId, Context.ConnectionAborted);
-
-                    if (primaryTeam != null)
-                    {
-                        teams.Add(primaryTeam);
-                    }
-                }
-
                 var groups = GetGroups(activeVirtualMachine.TeamIds, viewIds, userId, activeVirtualMachine.VmId);
-                await Clients.Groups(groups).SendAsync(VmHubMethods.ActiveVirtualMachine, null, userId, null, teams.Select(x => x.Id));
+                await Clients.Groups(groups).SendAsync(
+                    VmHubMethods.ActiveVirtualMachine,
+                    null,
+                    userId,
+                    null,
+                    activeVirtualMachine.TeamIds);
 
                 // Begin Handling of displaying current users connected to an individual VM
                 var userNamesByGroup = await _activeVirtualMachineService.GetActiveVirtualMachineUsersByGroup(activeVirtualMachine.VmId, activeVirtualMachine, cancellationToken);
 
                 foreach (var kvp in userNamesByGroup)
                 {
-                    await Clients.Groups(GetCurrentVmUsersChannelName(kvp.Key, activeVirtualMachine.VmId)).SendAsync(VmHubMethods.CurrentVirtualMachineUsers, activeVirtualMachine.VmId, kvp.Value);
+                    await Clients.Groups(GetCurrentVmUsersChannelName(kvp.Key, activeVirtualMachine.VmId)).SendAsync(
+                        VmHubMethods.CurrentVirtualMachineUsers,
+                        activeVirtualMachine.VmId,
+                        kvp.Value,
+                        kvp.Key);
                 }
 
                 await _vmUsageLoggingService.CloseVmLogEntry(userId, activeVirtualMachine.VmId, cancellationToken);

--- a/src/Player.Vm.Api/Features/Vms/Hubs/VmHub.cs
+++ b/src/Player.Vm.Api/Features/Vms/Hubs/VmHub.cs
@@ -44,9 +44,8 @@ namespace Player.Vm.Api.Features.Vms.Hubs
 
         public async Task JoinView(Guid viewId)
         {
-            var groupId = await _playerService.GetGroupIdForViewAsync(viewId, Context.ConnectionAborted);
-
-            if (groupId.HasValue)
+            var groupIds = await _playerService.GetGroupIdsForViewAsync(viewId, Context.ConnectionAborted);
+            foreach (var groupId in groupIds)
             {
                 await Groups.AddToGroupAsync(Context.ConnectionId, groupId.ToString());
             }
@@ -54,9 +53,8 @@ namespace Player.Vm.Api.Features.Vms.Hubs
 
         public async Task LeaveView(Guid viewId)
         {
-            var groupId = await _playerService.GetGroupIdForViewAsync(viewId, Context.ConnectionAborted);
-
-            if (groupId.HasValue)
+            var groupIds = await _playerService.GetGroupIdsForViewAsync(viewId, Context.ConnectionAborted);
+            foreach (var groupId in groupIds)
             {
                 await Groups.RemoveFromGroupAsync(Context.ConnectionId, groupId.ToString());
             }
@@ -65,16 +63,21 @@ namespace Player.Vm.Api.Features.Vms.Hubs
         public async Task<IEnumerable<VmUserTeam>> JoinViewUsers(Guid viewId)
         {
             var vmUserTeams = new List<VmUserTeam>();
-            var groupId = await _playerService.GetGroupIdForViewAsync(viewId, Context.ConnectionAborted);
+            var groupIds = await _playerService.GetGroupIdsForViewAsync(viewId, Context.ConnectionAborted);
 
-            if (!groupId.HasValue)
+            if (!groupIds.Any())
             {
                 return vmUserTeams;
             }
 
-            await Groups.AddToGroupAsync(Context.ConnectionId, GetGroup(groupId.Value));
+            foreach (var groupId in groupIds)
+            {
+                await Groups.AddToGroupAsync(Context.ConnectionId, GetGroup(groupId));
+            }
 
             var teams = await _playerService.GetTeamsByViewIdAsync(viewId, Context.ConnectionAborted);
+            if (teams == null)
+                return vmUserTeams;
 
             var teamTaskDict = new Dictionary<Guid, Task<IEnumerable<User>>>();
 
@@ -124,39 +127,26 @@ namespace Player.Vm.Api.Features.Vms.Hubs
 
         public async Task LeaveViewUsers(Guid viewId)
         {
-            var groupId = await _playerService.GetGroupIdForViewAsync(viewId, Context.ConnectionAborted);
-
-            if (groupId.HasValue)
+            var groupIds = await _playerService.GetGroupIdsForViewAsync(viewId, Context.ConnectionAborted);
+            foreach (var groupId in groupIds)
             {
-                await Groups.RemoveFromGroupAsync(Context.ConnectionId, GetGroup(groupId.Value));
+                await Groups.RemoveFromGroupAsync(Context.ConnectionId, GetGroup(groupId));
             }
         }
 
         public async Task<VmUser> JoinUser(Guid userId, Guid viewId, Guid teamId)
         {
+            if (!await _playerService.CanViewTeams([teamId], Context.ConnectionAborted))
+                throw new HubException("You do not have access to this team");
+
             var activeVm = _activeVirtualMachineService.GetActiveVirtualMachineForUser(userId);
-            Guid? activeVmId = null;
 
-            var groupId = await _playerService.GetGroupIdForViewAsync(viewId, Context.ConnectionAborted);
+            await Groups.AddToGroupAsync(Context.ConnectionId, GetGroup(teamId, userId));
 
-            if (groupId.HasValue)
-            {
-                if (groupId == viewId)
-                {
-                    await Groups.AddToGroupAsync(Context.ConnectionId, GetGroup(viewId, userId));
-                    activeVmId = activeVm?.VmId;
-                }
-                else
-                {
-                    // Check if this user's team is allowed to see the target user's activeVm
-                    if (activeVm != null && activeVm.TeamIds.Contains(groupId.Value))
-                    {
-                        activeVmId = activeVm.VmId;
-                    }
-
-                    await Groups.AddToGroupAsync(Context.ConnectionId, GetGroup(groupId.Value, userId));
-                }
-            }
+            // Check if this team is allowed to see the target user's active VM.
+            var activeVmId = activeVm != null && activeVm.TeamIds.Contains(teamId)
+                ? activeVm.VmId
+                : (Guid?)null;
 
             var user = await _playerService.GetUserById(userId, Context.ConnectionAborted);
             var dbUser = await _dbContext.VmUsers
@@ -168,8 +158,11 @@ namespace Player.Vm.Api.Features.Vms.Hubs
 
         public async Task LeaveUser(Guid userId, Guid viewId)
         {
-            var groupId = await _playerService.GetGroupIdForViewAsync(viewId, Context.ConnectionAborted);
-            await Groups.RemoveFromGroupAsync(Context.ConnectionId, GetGroup(groupId.Value, userId));
+            var groupIds = await _playerService.GetGroupIdsForViewAsync(viewId, Context.ConnectionAborted);
+            foreach (var groupId in groupIds)
+            {
+                await Groups.RemoveFromGroupAsync(Context.ConnectionId, GetGroup(groupId, userId));
+            }
         }
 
         public async Task JoinVm(Guid vmId)
@@ -186,30 +179,22 @@ namespace Player.Vm.Api.Features.Vms.Hubs
         {
             var vm = await _vmService.GetAsync(vmId, Context.ConnectionAborted);
             var viewIds = await _viewService.GetViewIdsForTeams(vm.TeamIds, Context.ConnectionAborted);
-
-            var teams = new List<Team>();
+            var groupIds = new HashSet<Guid>();
 
             foreach (var viewId in viewIds)
             {
-                var primaryTeam = await _playerService.GetPrimaryTeamByViewIdAsync(viewId, Context.ConnectionAborted);
-
-                if (primaryTeam != null)
-                {
-                    teams.Add(primaryTeam);
-                }
+                groupIds.UnionWith(await _playerService.GetGroupIdsForViewAsync(viewId, Context.ConnectionAborted));
             }
 
-            foreach (var team in teams)
+            foreach (var groupId in groupIds.Where(x => viewIds.Contains(x) || vm.TeamIds.Contains(x)))
             {
-                var groupId = await _playerService.GetGroupIdForViewAsync(team.ViewId, Context.ConnectionAborted);
-
                 if (join)
                 {
-                    await Groups.AddToGroupAsync(Context.ConnectionId, GetCurrentVmUsersChannelName(groupId.Value, vmId));
+                    await Groups.AddToGroupAsync(Context.ConnectionId, GetCurrentVmUsersChannelName(groupId, vmId));
                 }
                 else
                 {
-                    await Groups.RemoveFromGroupAsync(Context.ConnectionId, GetCurrentVmUsersChannelName(groupId.Value, vmId));
+                    await Groups.RemoveFromGroupAsync(Context.ConnectionId, GetCurrentVmUsersChannelName(groupId, vmId));
                 }
             }
         }

--- a/src/Player.Vm.Api/Features/Vms/Queries/GetVmPermissions.cs
+++ b/src/Player.Vm.Api/Features/Vms/Queries/GetVmPermissions.cs
@@ -45,16 +45,16 @@ public class GetVmPermissions
 
             await Task.WhenAll(tasks);
 
-            var primaryPermissions = tasks
-                .SelectMany(x => x.Result.Where(y => y.IsPrimary))
+            var relevantPermissions = tasks
+                .SelectMany(x => x.Result.Where(y => y.IsPrimary || teamIds.Contains(y.TeamId)))
                 .SelectMany(x => x.PermissionValues);
 
-            var appViewPermissions = primaryPermissions
+            var appViewPermissions = relevantPermissions
                 .Select(x => Enum.TryParse<AppViewPermission>(x, out var p) ? p : (AppViewPermission?)null)
                 .Where(p => p.HasValue)
                 .Select(p => p.Value);
 
-            var appTeamPermissions = primaryPermissions
+            var appTeamPermissions = relevantPermissions
                 .Select(x => Enum.TryParse<AppTeamPermission>(x, out var p) ? p : (AppTeamPermission?)null)
                 .Where(p => p.HasValue)
                 .Select(p => p.Value);

--- a/src/Player.Vm.Api/Features/Vms/Queries/GetVmPermissions.cs
+++ b/src/Player.Vm.Api/Features/Vms/Queries/GetVmPermissions.cs
@@ -25,14 +25,12 @@ public class GetVmPermissions
         public Guid Id { get; set; }
     }
 
-    public class Handler(VmContext db, IViewService viewService, IPlayerApiClient playerApiClient) : IRequestHandler<Query, VmPermissionResult>
+    public class Handler(IVmService vmService, IViewService viewService, IPlayerApiClient playerApiClient) : IRequestHandler<Query, VmPermissionResult>
     {
         public async Task<VmPermissionResult> Handle(Query request, CancellationToken cancellationToken)
         {
-            var teamIds = await db.VmTeams
-                .Where(x => x.VmId == request.Id)
-                .Select(x => x.TeamId)
-                .ToArrayAsync(cancellationToken);
+            var vm = await vmService.GetAsync(request.Id, cancellationToken);
+            var teamIds = vm.TeamIds.ToArray();
 
             var viewIds = await viewService.GetViewIdsForTeams(teamIds, cancellationToken);
 
@@ -40,24 +38,30 @@ public class GetVmPermissions
 
             foreach (var viewId in viewIds)
             {
-                tasks.Add(playerApiClient.GetMyTeamPermissionsAsync(viewId, null, true));
+                tasks.Add(playerApiClient.GetMyTeamPermissionsAsync(viewId, null, true, cancellationToken));
             }
 
             await Task.WhenAll(tasks);
 
-            var relevantPermissions = tasks
-                .SelectMany(x => x.Result.Where(y => y.IsPrimary || teamIds.Contains(y.TeamId)))
-                .SelectMany(x => x.PermissionValues);
+            var claims = tasks.SelectMany(x => x.Result);
+            var targetPermissionValues = claims
+                .Where(x => teamIds.Contains(x.TeamId))
+                .SelectMany(x => x.PermissionValues ?? []);
+            var directViewPermissionValues = claims
+                .SelectMany(x => x.DirectPermissionValues ?? []);
 
-            var appViewPermissions = relevantPermissions
+            var appViewPermissions = targetPermissionValues
+                .Concat(directViewPermissionValues)
                 .Select(x => Enum.TryParse<AppViewPermission>(x, out var p) ? p : (AppViewPermission?)null)
                 .Where(p => p.HasValue)
-                .Select(p => p.Value);
+                .Select(p => p.Value)
+                .Distinct();
 
-            var appTeamPermissions = relevantPermissions
+            var appTeamPermissions = targetPermissionValues
                 .Select(x => Enum.TryParse<AppTeamPermission>(x, out var p) ? p : (AppTeamPermission?)null)
                 .Where(p => p.HasValue)
-                .Select(p => p.Value);
+                .Select(p => p.Value)
+                .Distinct();
 
             return new VmPermissionResult
             {

--- a/src/Player.Vm.Api/Features/Vms/VmService.cs
+++ b/src/Player.Vm.Api/Features/Vms/VmService.cs
@@ -121,10 +121,11 @@ namespace Player.Vm.Api.Features.Vms
             if (!visibility.TeamIds.Contains(teamId))
                 throw new ForbiddenException();
 
-            var vmQuery = _context.VmTeams
+            IQueryable<Domain.Models.Vm> vmQuery = _context.VmTeams
                 .Where(v => v.TeamId == teamId)
                 .Select(v => v.Vm)
-                .Distinct();
+                .Distinct()
+                .Include(v => v.VmTeams);
 
             if (onlyMine)
             {
@@ -160,7 +161,7 @@ namespace Player.Vm.Api.Features.Vms
                 }
             }
 
-            return _mapper.Map<IEnumerable<Vm>>(vmList);
+            return MapVisibleCollection(vmList, visibility.TeamIds);
         }
 
         public async Task<IEnumerable<Vm>> GetByViewIdAsync(Guid viewId, string name, bool includePersonal, bool onlyMine, CancellationToken ct)
@@ -229,7 +230,23 @@ namespace Player.Vm.Api.Features.Vms
                 }
             }
 
-            return _mapper.Map<IEnumerable<Vm>>(vmList);
+            return MapVisibleCollection(vmList, visibility.TeamIds);
+        }
+
+        private IEnumerable<Vm> MapVisibleCollection(
+            IEnumerable<Domain.Models.Vm> vmEntities,
+            IReadOnlySet<Guid> visibleTeamIds)
+        {
+            var models = _mapper.Map<IEnumerable<Vm>>(vmEntities).ToArray();
+
+            foreach (var model in models)
+            {
+                model.TeamIds = (model.TeamIds ?? [])
+                    .Where(visibleTeamIds.Contains)
+                    .ToArray();
+            }
+
+            return models;
         }
 
         public async Task<Vm> CreateAsync(VmCreateForm form, CancellationToken ct)

--- a/src/Player.Vm.Api/Features/Vms/VmService.cs
+++ b/src/Player.Vm.Api/Features/Vms/VmService.cs
@@ -159,16 +159,20 @@ namespace Player.Vm.Api.Features.Vms
         {
             List<Domain.Models.Vm> vmList = new List<Domain.Models.Vm>();
             var teams = await _playerService.GetTeamsByViewIdAsync(viewId, ct);
+            if (teams == null)
+                return [];
+
             var teamIds = teams.Select(t => t.Id);
 
             if (onlyMine)
             {
                 var vmQuery = _context.VmTeams
-                .Include(v => v.Vm)
-                .Where(v => teamIds.Contains(v.TeamId))
-                .Where(v => v.Vm.UserId.HasValue && v.Vm.UserId == _user.GetId());
+                    .Include(v => v.Vm)
+                    .ThenInclude(v => v.VmTeams)
+                    .Where(v => teamIds.Contains(v.TeamId))
+                    .Where(v => v.Vm.UserId.HasValue && v.Vm.UserId == _user.GetId());
 
-                var vmTeams = await vmQuery.ToListAsync();
+                var vmTeams = await vmQuery.ToListAsync(ct);
                 vmList = vmTeams.Select(v => v.Vm).Distinct().ToList();
 
                 if (vmList.Count > 1)
@@ -205,17 +209,14 @@ namespace Player.Vm.Api.Features.Vms
                 {
                     var personalVms = vmList.Where(v => v.UserId.HasValue).ToList();
 
-                    if (personalVms.Any())
+                    foreach (var userVm in personalVms)
                     {
-                        if (!await _playerService.Can(teamIds, [], [AppSystemPermission.ViewViews], [AppViewPermission.ViewView], [], ct))
+                        var userVmTeamIds = userVm.VmTeams.Select(x => x.TeamId);
+
+                        if (userVm.UserId.Value != _user.GetId()
+                            && !await _playerService.Can(userVmTeamIds, [], [AppSystemPermission.ViewViews], [AppViewPermission.ViewView], [], ct))
                         {
-                            foreach (var userVm in personalVms)
-                            {
-                                if (userVm.UserId.Value != _user.GetId())
-                                {
-                                    vmList.Remove(userVm);
-                                }
-                            }
+                            vmList.Remove(userVm);
                         }
                     }
                 }
@@ -387,10 +388,10 @@ namespace Player.Vm.Api.Features.Vms
             if (maps == null)
                 return null;
 
-            var primTeam = await _playerService.GetPrimaryTeamByViewIdAsync(viewId, ct);
+            var teams = await _playerService.GetTeamsByViewIdAsync(viewId, ct);
 
-            // If primTeam is null, view doesn't exist in Player API
-            if (primTeam == null)
+            // If teams is null, view doesn't exist in Player API
+            if (teams == null)
                 return null;
 
             // Only return the maps user has access to
@@ -545,14 +546,14 @@ namespace Player.Vm.Api.Features.Vms
             if (teamIDs != null && teamIDs.Count > 0)
             {
                 // Make sure all teams exist and are part of this view
-                var viewTeamsModels = await _playerService.GetTeamsByViewIdAsync(viewId, ct);
-                var viewTeams = viewTeamsModels.Select(t => t.Id).ToList();
                 foreach (Guid teamId in teamIDs)
                 {
-                    if (await _playerService.GetTeamById(teamId) == null)
+                    var team = await _playerService.GetTeamById(teamId);
+
+                    if (team == null)
                         throw new ForbiddenException("Team with id " + teamId + " does not exist");
 
-                    if (!viewTeams.Contains(teamId))
+                    if (team.ViewId != viewId)
                         throw new ForbiddenException("Team with id " + teamId + " is not a member of the specified view");
                 }
 

--- a/src/Player.Vm.Api/Features/Vms/VmService.cs
+++ b/src/Player.Vm.Api/Features/Vms/VmService.cs
@@ -102,7 +102,14 @@ namespace Player.Vm.Api.Features.Vms
             if (!await _playerService.CanViewTeams(teamIds, ct))
                 throw new ForbiddenException();
 
-            if (vm.UserId.HasValue && vm.UserId != _user.GetId() && !await _playerService.Can(teamIds, [], [AppSystemPermission.ViewViews], [AppViewPermission.ViewView], [], ct))
+            if (vm.UserId.HasValue && vm.UserId != _user.GetId() &&
+                !await _playerService.Can(
+                    teamIds,
+                    [],
+                    [AppSystemPermission.ViewViews, AppSystemPermission.ManageViews],
+                    [AppViewPermission.ViewView, AppViewPermission.ManageView],
+                    [],
+                    ct))
                 throw new ForbiddenException("This machine belongs to another user");
 
             return true;
@@ -110,7 +117,8 @@ namespace Player.Vm.Api.Features.Vms
 
         public async Task<IEnumerable<Vm>> GetByTeamIdAsync(Guid teamId, string name, bool includePersonal, bool onlyMine, CancellationToken ct)
         {
-            if (!await _playerService.CanViewTeams([teamId], ct))
+            var visibility = await _playerService.GetVisibilityContextForTeamAsync(teamId, ct);
+            if (!visibility.TeamIds.Contains(teamId))
                 throw new ForbiddenException();
 
             var vmQuery = _context.VmTeams
@@ -139,7 +147,7 @@ namespace Player.Vm.Api.Features.Vms
 
                 if (personalVms.Any())
                 {
-                    if (!await _playerService.Can([teamId], [], [AppSystemPermission.ViewViews], [AppViewPermission.ViewView], [], ct))
+                    if (!visibility.CanViewAllTeams)
                     {
                         foreach (var userVm in personalVms)
                         {
@@ -158,6 +166,7 @@ namespace Player.Vm.Api.Features.Vms
         public async Task<IEnumerable<Vm>> GetByViewIdAsync(Guid viewId, string name, bool includePersonal, bool onlyMine, CancellationToken ct)
         {
             List<Domain.Models.Vm> vmList = new List<Domain.Models.Vm>();
+            var visibility = await _playerService.GetVisibilityContextAsync(viewId, ct);
             var teams = await _playerService.GetTeamsByViewIdAsync(viewId, ct);
             if (teams == null)
                 return [];
@@ -211,10 +220,8 @@ namespace Player.Vm.Api.Features.Vms
 
                     foreach (var userVm in personalVms)
                     {
-                        var userVmTeamIds = userVm.VmTeams.Select(x => x.TeamId);
-
-                        if (userVm.UserId.Value != _user.GetId()
-                            && !await _playerService.Can(userVmTeamIds, [], [AppSystemPermission.ViewViews], [AppViewPermission.ViewView], [], ct))
+                        if (userVm.UserId.Value != _user.GetId() &&
+                            !visibility.CanViewAllTeams)
                         {
                             vmList.Remove(userVm);
                         }
@@ -388,21 +395,18 @@ namespace Player.Vm.Api.Features.Vms
             if (maps == null)
                 return null;
 
+            var visibility = await _playerService.GetVisibilityContextAsync(viewId, ct);
             var teams = await _playerService.GetTeamsByViewIdAsync(viewId, ct);
 
             // If teams is null, view doesn't exist in Player API
             if (teams == null)
                 return null;
 
-            // Only return the maps user has access to
-            var accessableMaps = new List<Domain.Models.VmMap>();
-            foreach (var m in maps)
-            {
-                if (await _playerService.CanViewTeams(m.TeamIds, ct))
-                    accessableMaps.Add(m);
-            }
+            var accessibleMaps = maps
+                .Where(x => x.TeamIds.Any(visibility.TeamIds.Contains))
+                .ToArray();
 
-            return _mapper.Map<VmMap[]>(accessableMaps);
+            return _mapper.Map<VmMap[]>(accessibleMaps);
         }
 
         public async Task<VmMap> GetMapAsync(Guid mapId, CancellationToken ct)
@@ -423,8 +427,7 @@ namespace Player.Vm.Api.Features.Vms
 
         public async Task<VmMap> GetTeamMapAsync(Guid teamId, CancellationToken ct)
         {
-            // Check user can access this team
-            if (!await _playerService.CanViewTeams([teamId], ct))
+            if (!await _playerService.IsTeamVisibleAsync(teamId, ct))
                 throw new ForbiddenException();
 
             var maps = await _context.Maps

--- a/src/Player.Vm.Api/Hubs/VmHub.cs
+++ b/src/Player.Vm.Api/Hubs/VmHub.cs
@@ -21,9 +21,8 @@ namespace Player.Vm.Api.Hubs
 
         public async Task JoinView(Guid viewId)
         {
-            var groupId = await _playerService.GetGroupIdForViewAsync(viewId, Context.ConnectionAborted);
-
-            if (groupId.HasValue)
+            var groupIds = await _playerService.GetGroupIdsForViewAsync(viewId, Context.ConnectionAborted);
+            foreach (var groupId in groupIds)
             {
                 await Groups.AddToGroupAsync(Context.ConnectionId, groupId.ToString());
             }
@@ -31,9 +30,8 @@ namespace Player.Vm.Api.Hubs
 
         public async Task LeaveView(Guid viewId)
         {
-            var groupId = await _playerService.GetGroupIdForViewAsync(viewId, Context.ConnectionAborted);
-
-            if (groupId.HasValue)
+            var groupIds = await _playerService.GetGroupIdsForViewAsync(viewId, Context.ConnectionAborted);
+            foreach (var groupId in groupIds)
             {
                 await Groups.RemoveFromGroupAsync(Context.ConnectionId, groupId.ToString());
             }

--- a/src/Player.Vm.Api/Infrastructure/Exceptions/Middleware/ExceptionMiddleware.cs
+++ b/src/Player.Vm.Api/Infrastructure/Exceptions/Middleware/ExceptionMiddleware.cs
@@ -83,6 +83,12 @@ namespace Player.Vm.Api.Infrastructure.Exceptions.Middleware
                 statusCode = (exception as IApiException).GetStatusCode();
                 _logger.LogDebug($"API Exception: {exception}");
             }
+            else if (exception is Player.Api.Client.ApiException playerApiException
+                && playerApiException.StatusCode == (int)HttpStatusCode.NotFound)
+            {
+                statusCode = HttpStatusCode.NotFound;
+                _logger.LogDebug($"Player API resource not found: {exception}");
+            }
             else
             {
                 _logger.LogError($"Unhandled Exception: {exception}");

--- a/src/Player.Vm.Api/Player.Vm.Api.csproj
+++ b/src/Player.Vm.Api/Player.Vm.Api.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="13.0.1"/> <!-- DO NOT UPDATE. Version 15+ requires a license. Plan to migrate to something else. -->
-    <PackageReference Include="Player.Api.Client" Version="3.4.3"/>
+    <PackageReference Include="Player.Api.Client" Version="3.5.1-rc3"/>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Player.Vm.Api/Player.Vm.Api.csproj
+++ b/src/Player.Vm.Api/Player.Vm.Api.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="13.0.1"/> <!-- DO NOT UPDATE. Version 15+ requires a license. Plan to migrate to something else. -->
-    <PackageReference Include="Player.Api.Client" Version="3.5.1-rc3"/>
+    <PackageReference Include="Player.Api.Client" Version="3.5.1"/>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary

This change makes the VM API honor the new scoped-teams setup from Player. When a team is configured to see related teams, VM lists, maps, recent VM activity, and active-user information include those scoped teams while still keeping unrelated teams out of the normal view.

## User-facing changes

- VM lists and VM team groupings are limited to the primary team plus teams visible from that primary team.
- Map lists and team map reads only return maps for teams visible in the current primary context.
- Active VM and last VM updates are recorded for the user's current primary-context teams, not every team membership.
- Connected-user rosters are scoped to the teams or view groups the current connection is authorized to see.
- Elevated access to a VM no longer makes that user appear active to unrelated team panels.

## Implementation details

- Adds a `VisibilityContext` in `PlayerService` based on primary claims, `DirectPermissionValues`, and `SourceTeamIds`.
- Updates VM and map collection reads to trim returned team ids to the current visibility set.
- Keeps direct VM/map/action authorization on effective permissions for the target teams.
- Changes VM hub group joins to subscribe to all authorized team/view presence groups.
- Extends `CurrentVirtualMachineUsers` notifications with the source `groupId` so clients can merge authorized snapshots.
